### PR TITLE
feat(context-selector): add OrgUnitSelect

### DIFF
--- a/src/current-user/current-user-provider.js
+++ b/src/current-user/current-user-provider.js
@@ -8,15 +8,7 @@ const query = {
     me: {
         resource: 'me',
         params: {
-            fields: [
-                'id',
-                'authorities',
-                'programs',
-                'dataSets',
-                'userGroups',
-                'organisationUnits',
-                'dataViewOrganisationUnits',
-            ],
+            fields: ['id', 'authorities', 'organisationUnits'],
         },
     },
     dataApprovalWorkflows: {
@@ -25,7 +17,13 @@ const query = {
         resource: 'dataApprovalWorkflows',
         params: {
             paging: false,
-            fields: ['id', 'displayName', 'dataApprovalLevels', 'periodType'],
+            fields: [
+                'id',
+                'displayName',
+                'dataApprovalLevels',
+                'periodType',
+                'dataSets[id,displayName]',
+            ],
         },
     },
 }

--- a/src/navigation/push-state-to-history.js
+++ b/src/navigation/push-state-to-history.js
@@ -6,6 +6,7 @@ export const pushStateToHistory = state => {
         wf: state.workflow.id,
         pe: state.period.id,
         ou: state.orgUnit.path,
+        ouDisplayName: state.orgUnit.displayName,
     })
 
     const search = paramString ? `?${paramString}` : ''

--- a/src/navigation/read-query-params.js
+++ b/src/navigation/read-query-params.js
@@ -9,5 +9,6 @@ export const readQueryParams = () => {
         wf: params.wf,
         pe: params.pe,
         ou: params.ou,
+        ouDisplayName: params.ouDisplayName,
     }
 }

--- a/src/top-bar/context-select/context-select.js
+++ b/src/top-bar/context-select/context-select.js
@@ -56,7 +56,7 @@ const ContextSelect = ({
                 <Popover
                     reference={buttonRef}
                     arrow={false}
-                    placement="bottom-start"
+                    placement="bottom-end"
                     onClickOutside={onClose}
                 >
                     {children}

--- a/src/top-bar/org-unit-select/org-unit-select.js
+++ b/src/top-bar/org-unit-select/org-unit-select.js
@@ -1,13 +1,19 @@
 import i18n from '@dhis2/d2-i18n'
+import { OrganisationUnitTree } from '@dhis2/ui'
 import React from 'react'
+import { useCurrentUser } from '../../current-user/index.js'
 import { ContextSelect } from '../context-select/index.js'
 import { useSelectionContext } from '../selection/index.js'
+import classes from './org-unit-select.module.css'
 
+useCurrentUser
 const ORG_UNIT = 'ORG_UNIT'
 
 const OrgUnitSelect = () => {
+    const { organisationUnits } = useCurrentUser()
     const {
-        orgUnit /*, setOrgUnit */,
+        orgUnit,
+        selectOrgUnit,
         workflow,
         period,
         openedSelect,
@@ -18,6 +24,11 @@ const OrgUnitSelect = () => {
     const requiredValuesMessage = workflow.id
         ? i18n.t('Choose a period first')
         : i18n.t('Choose a workflow and period first')
+    const roots = organisationUnits.map(({ id }) => id)
+    const onChange = ({ displayName, id, path }) => {
+        selectOrgUnit({ displayName, id, path })
+    }
+    const selectedOrgUnitPath = orgUnit.path ? [orgUnit.path] : undefined
 
     return (
         <ContextSelect
@@ -29,7 +40,15 @@ const OrgUnitSelect = () => {
             onClose={() => setOpenedSelect('')}
             requiredValuesMessage={requiredValuesMessage}
         >
-            <pre>Org Unit picker placeholder</pre>
+            <div className={classes.scrollbox}>
+                <OrganisationUnitTree
+                    roots={roots}
+                    onChange={onChange}
+                    initiallyExpanded={selectedOrgUnitPath}
+                    selected={selectedOrgUnitPath}
+                    singleSelection
+                />
+            </div>
         </ContextSelect>
     )
 }

--- a/src/top-bar/org-unit-select/org-unit-select.js
+++ b/src/top-bar/org-unit-select/org-unit-select.js
@@ -6,8 +6,7 @@ import { ContextSelect } from '../context-select/index.js'
 import { useSelectionContext } from '../selection/index.js'
 import classes from './org-unit-select.module.css'
 
-useCurrentUser
-const ORG_UNIT = 'ORG_UNIT'
+export const ORG_UNIT = 'ORG_UNIT'
 
 const OrgUnitSelect = () => {
     const { organisationUnits } = useCurrentUser()

--- a/src/top-bar/org-unit-select/org-unit-select.module.css
+++ b/src/top-bar/org-unit-select/org-unit-select.module.css
@@ -1,0 +1,7 @@
+.scrollbox {
+    min-width: 250px;
+    max-width: 500px;
+    min-height: 200px;
+    max-height: 500px;
+    overflow-y: auto;
+}

--- a/src/top-bar/org-unit-select/org-unit-select.module.css
+++ b/src/top-bar/org-unit-select/org-unit-select.module.css
@@ -4,4 +4,5 @@
     min-height: 200px;
     max-height: 500px;
     overflow-y: auto;
+    padding: var(--spacers-dp8);
 }

--- a/src/top-bar/org-unit-select/org-unit-select.test.js
+++ b/src/top-bar/org-unit-select/org-unit-select.test.js
@@ -1,0 +1,264 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import { Popover, Layer, OrganisationUnitTree, Tooltip } from '@dhis2/ui'
+import { shallow } from 'enzyme'
+import React from 'react'
+import { useCurrentUser } from '../../current-user/index.js'
+import { readQueryParams } from '../../navigation/read-query-params.js'
+import { ContextSelect } from '../context-select/context-select.js'
+import { useSelectionContext } from '../selection/index.js'
+import { ORG_UNIT, OrgUnitSelect } from './org-unit-select.js'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useDataQuery: jest.fn(),
+}))
+jest.mock('../../navigation/read-query-params.js', () => ({
+    readQueryParams: jest.fn(),
+}))
+
+jest.mock('../../current-user/index.js', () => ({
+    useCurrentUser: jest.fn(),
+}))
+
+jest.mock('../selection/index.js', () => ({
+    useSelectionContext: jest.fn(),
+}))
+
+const mockWorkflows = [
+    {
+        displayName: 'Workflow a',
+        id: 'i5m0JPw4DQi',
+        periodType: 'Daily',
+    },
+    {
+        displayName: 'Workflow B',
+        id: 'rIUL3hYOjJc',
+        periodType: 'Daily',
+    },
+]
+const mockOrgUnitRoots = [
+    {
+        id: 'ImspTQPwCqd',
+        displayName: 'Sierra Leone',
+    },
+]
+
+afterEach(() => {
+    jest.resetAllMocks()
+})
+
+beforeEach(() => {
+    useCurrentUser.mockImplementation(() => ({
+        dataApprovalWorkflows: mockWorkflows,
+        organisationUnits: mockOrgUnitRoots,
+    }))
+    readQueryParams.mockImplementation(() => ({}))
+})
+
+describe('<OrgUnitSelect>', () => {
+    it('renders an OrganisationUnitTree in a ContextSelect', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {},
+            period: {},
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+        const wrapper = shallow(<OrgUnitSelect />)
+        expect(wrapper.type()).toBe(ContextSelect)
+        expect(wrapper.find(OrganisationUnitTree)).toHaveLength(1)
+    })
+
+    it('renders a placeholder text when no organisation unit is selected', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {},
+            period: {},
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+        const wrapper = shallow(<OrgUnitSelect />)
+
+        expect(wrapper.find(ContextSelect).prop('value')).toBe(
+            'Choose an organisation unit'
+        )
+    })
+
+    it('renders the value when a organisation unit is selected', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {
+                id: '20120402',
+            },
+            orgUnit: {
+                path: '/ImspTQPwCqd',
+                displayName: 'test',
+            },
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+        const wrapper = shallow(<OrgUnitSelect />)
+
+        expect(wrapper.find(ContextSelect).prop('value')).toBe('test')
+    })
+
+    it('opens the ContextSelect when the opened select matches "ORG_UNIT"', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {
+                id: '20120402',
+            },
+            orgUnit: {},
+            openedSelect: ORG_UNIT,
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+        const wrapper = shallow(<OrgUnitSelect />)
+
+        expect(wrapper.find(ContextSelect).prop('open')).toBe(true)
+    })
+
+    it('calls the setOpenedSelect to open when clicking the ContextSelect button', () => {
+        const setOpenedSelect = jest.fn()
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {
+                id: '20120402',
+            },
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect,
+        }))
+
+        shallow(<OrgUnitSelect />)
+            .find(ContextSelect)
+            .dive()
+            .find('button')
+            .simulate('click')
+
+        expect(setOpenedSelect).toHaveBeenCalledTimes(1)
+        expect(setOpenedSelect).toHaveBeenCalledWith(ORG_UNIT)
+    })
+
+    it('calls selectOrgUnit when clicking a node in the org unit tree', () => {
+        useDataQuery.mockImplementation(() => ({
+            error: null,
+            loading: false,
+            data: {
+                ImspTQPwCqd: {
+                    id: 'ImspTQPwCqd',
+                    path: '/ImspTQPwCqd',
+                    displayName: 'Sierra Leone',
+                    children: [],
+                },
+            },
+        }))
+        const selectOrgUnit = jest.fn()
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {
+                id: '20120402',
+            },
+            orgUnit: {},
+            openedSelect: ORG_UNIT,
+            selectOrgUnit,
+        }))
+
+        // This test is quite brittle due to this selector ¯\_(ツ)_/¯
+        const clickableNode = shallow(<OrgUnitSelect />)
+            .find(OrganisationUnitTree)
+            .dive()
+            .find('OrganisationUnitNode')
+            .dive()
+            .find('Node')
+            .dive()
+            .find('Label')
+            .dive()
+            .find('SingleSelectionLabel')
+            .dive()
+            .find('span')
+
+        clickableNode.simulate('click')
+
+        expect(selectOrgUnit).toHaveBeenCalledTimes(1)
+        expect(selectOrgUnit).toHaveBeenCalledWith({
+            displayName: 'Sierra Leone',
+            id: 'ImspTQPwCqd',
+            path: '/ImspTQPwCqd',
+        })
+    })
+
+    it('calls the setOpenedSelect to close when clicking the backdrop', () => {
+        const setOpenedSelect = jest.fn()
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {
+                id: '20120402',
+            },
+            orgUnit: {},
+            openedSelect: ORG_UNIT,
+            selectWorkflow: () => {},
+            setOpenedSelect,
+        }))
+
+        shallow(<OrgUnitSelect />)
+            .find(ContextSelect)
+            .dive()
+            .find(Popover)
+            .dive()
+            .find(Layer)
+            .simulate('click')
+
+        expect(setOpenedSelect).toHaveBeenCalledTimes(1)
+        expect(setOpenedSelect).toHaveBeenCalledWith('')
+    })
+
+    it('displays the correct tooltip text when workflow and period have not been set yet', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {},
+            period: {},
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+
+        const wrapper = shallow(<OrgUnitSelect />)
+        const tooltip = wrapper.find(ContextSelect).dive().find(Tooltip)
+
+        expect(tooltip.prop('content')).toBe(
+            'Choose a workflow and period first'
+        )
+    })
+
+    it('displays the correct tooltip text when period has not been set yet', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {
+                id: 'i5m0JPw4DQi',
+            },
+            period: {},
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+
+        const wrapper = shallow(<OrgUnitSelect />)
+        const tooltip = wrapper.find(ContextSelect).dive().find(Tooltip)
+
+        expect(tooltip.prop('content')).toBe('Choose a period first')
+    })
+})

--- a/src/top-bar/period-select/period-select.test.js
+++ b/src/top-bar/period-select/period-select.test.js
@@ -1,4 +1,4 @@
-import { Popover, Layer, MenuItem } from '@dhis2/ui'
+import { Popover, Layer, MenuItem, Tooltip } from '@dhis2/ui'
 import { shallow } from 'enzyme'
 import React from 'react'
 import { useCurrentUser } from '../../current-user/index.js'
@@ -21,29 +21,32 @@ jest.mock('../selection/index.js', () => ({
     useSelectionContext: jest.fn(),
 }))
 
+const mockWorkflows = [
+    {
+        displayName: 'Workflow a',
+        id: 'i5m0JPw4DQi',
+        periodType: 'Monthly',
+    },
+    {
+        displayName: 'Workflow B',
+        id: 'rIUL3hYOjJc',
+        periodType: 'Yearly',
+    },
+]
+
+beforeEach(() => {
+    useCurrentUser.mockImplementation(() => ({
+        dataApprovalWorkflows: mockWorkflows,
+    }))
+    readQueryParams.mockImplementation(() => ({}))
+})
+
 afterEach(() => {
     jest.resetAllMocks()
 })
 
 describe('<PeriodSelect>', () => {
-    const mockWorkflows = [
-        {
-            displayName: 'Workflow a',
-            id: 'i5m0JPw4DQi',
-            periodType: 'Monthly',
-        },
-        {
-            displayName: 'Workflow B',
-            id: 'rIUL3hYOjJc',
-            periodType: 'Yearly',
-        },
-    ]
-
     it('renders a ContextSelect with YearNavigator and PeriodMenu', () => {
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {},
@@ -59,10 +62,6 @@ describe('<PeriodSelect>', () => {
     })
 
     it('renders a placeholder text when no period is selected', () => {
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {},
@@ -80,10 +79,6 @@ describe('<PeriodSelect>', () => {
     it('renders a the value when a period is selected', () => {
         const displayName = 'April 2012'
 
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {
@@ -100,10 +95,6 @@ describe('<PeriodSelect>', () => {
     })
 
     it('opens the ContextSelect when the opened select matches "PERIOD"', () => {
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {},
@@ -118,10 +109,6 @@ describe('<PeriodSelect>', () => {
 
     it('calls the setOpenedSelect to open when clicking the ContextSelect button', () => {
         const setOpenedSelect = jest.fn()
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {},
@@ -141,10 +128,6 @@ describe('<PeriodSelect>', () => {
 
     it('calls selectPeriod when clicking a MenuItem', () => {
         const selectPeriod = jest.fn()
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {
@@ -177,10 +160,6 @@ describe('<PeriodSelect>', () => {
 
     it('calls the setOpenedSelect to close when clicking the backdrop', () => {
         const setOpenedSelect = jest.fn()
-        useCurrentUser.mockImplementation(() => ({
-            dataApprovalWorkflows: mockWorkflows,
-        }))
-        readQueryParams.mockImplementation(() => ({}))
         useSelectionContext.mockImplementation(() => ({
             workflow: mockWorkflows[0],
             period: {},
@@ -199,5 +178,21 @@ describe('<PeriodSelect>', () => {
 
         expect(setOpenedSelect).toHaveBeenCalledTimes(1)
         expect(setOpenedSelect).toHaveBeenCalledWith('')
+    })
+
+    it('displays the correct tooltip text when period has not been set yet', () => {
+        useSelectionContext.mockImplementation(() => ({
+            workflow: {},
+            period: {},
+            orgUnit: {},
+            openedSelect: '',
+            selectWorkflow: () => {},
+            setOpenedSelect: () => {},
+        }))
+
+        const wrapper = shallow(<PeriodSelect />)
+        const tooltip = wrapper.find(ContextSelect).dive().find(Tooltip)
+
+        expect(tooltip.prop('content')).toBe('Choose a workflow first')
     })
 })

--- a/src/top-bar/selection/initial-values.js
+++ b/src/top-bar/selection/initial-values.js
@@ -26,7 +26,7 @@ export const initialWorkflowValue = (workflows, workflowId) => {
     return {}
 }
 
-const initialPeriodValue = (periodId, initialWorkflow) => {
+export const initialPeriodValue = (periodId, initialWorkflow = {}) => {
     if (!periodId || !initialWorkflow.id) {
         return {}
     }
@@ -34,6 +34,6 @@ const initialPeriodValue = (periodId, initialWorkflow) => {
     return parsePeriodId(periodId, [initialWorkflow.periodType]) || {}
 }
 
-const initialOrgUnitValue = (path, displayName) => {
-    return path && displayName ? { path /*, displayName */ } : {}
+export const initialOrgUnitValue = (path, displayName) => {
+    return path && displayName ? { path, displayName } : {}
 }

--- a/src/top-bar/selection/initial-values.js
+++ b/src/top-bar/selection/initial-values.js
@@ -2,10 +2,10 @@ import { readQueryParams } from '../../navigation/index.js'
 import { parsePeriodId } from '../period-select/index.js'
 
 export const initialValues = workflows => {
-    const { wf, pe, ou } = readQueryParams()
+    const { wf, pe, ou, ouDisplayName } = readQueryParams()
     const workflow = initialWorkflowValue(workflows, wf)
     const period = initialPeriodValue(pe, workflow)
-    const orgUnit = initialOrgUnitValue(ou)
+    const orgUnit = initialOrgUnitValue(ou, ouDisplayName)
 
     return { workflow, period, orgUnit }
 }
@@ -34,10 +34,6 @@ const initialPeriodValue = (periodId, initialWorkflow) => {
     return parsePeriodId(periodId, [initialWorkflow.periodType]) || {}
 }
 
-const initialOrgUnitValue = orgUnitPath => {
-    return orgUnitPath
-        ? {
-              path: orgUnitPath,
-          }
-        : {}
+const initialOrgUnitValue = (path, displayName) => {
+    return path && displayName ? { path /*, displayName */ } : {}
 }

--- a/src/top-bar/selection/initial-values.test.js
+++ b/src/top-bar/selection/initial-values.test.js
@@ -1,0 +1,90 @@
+import {
+    initialWorkflowValue,
+    initialPeriodValue,
+    initialOrgUnitValue,
+} from './initial-values.js'
+
+describe('initialWorkflowValue', () => {
+    const mockWorkflows = [
+        {
+            displayName: 'Workflow a',
+            id: 'i5m0JPw4DQi',
+            periodType: 'Daily',
+        },
+        {
+            displayName: 'Workflow B',
+            id: 'rIUL3hYOjJc',
+            periodType: 'Daily',
+        },
+    ]
+
+    it('returns an empty object by default', () => {
+        expect(initialWorkflowValue([])).toEqual({})
+    })
+
+    it('returns the workflow with the provided ID if it exists', () => {
+        expect(initialWorkflowValue(mockWorkflows, 'i5m0JPw4DQi')).toEqual(
+            mockWorkflows[0]
+        )
+    })
+
+    it('returns an empty object if the specified ID is not present on a workflow', () => {
+        expect(initialWorkflowValue(mockWorkflows, 'invalid_value')).toEqual({})
+    })
+
+    it('returns the only workflow if only one workflow exist and no ID is specified', () => {
+        expect(initialWorkflowValue([mockWorkflows[0]])).toEqual(
+            mockWorkflows[0]
+        )
+    })
+})
+
+describe('initialPeriodValue', () => {
+    const initialWorkflow = {
+        displayName: 'Workflow a',
+        id: 'i5m0JPw4DQi',
+        periodType: 'Daily',
+    }
+    it('returns an empty object by default', () => {
+        expect(initialPeriodValue()).toEqual({})
+    })
+    it('returns an empty object when provided with an invalid period ID', () => {
+        const invalidPeriodID = 'invalidPeriodID'
+        expect(initialPeriodValue(invalidPeriodID, initialWorkflow)).toEqual({})
+    })
+    it('returns an empty object if the periodId does not match the workflow periodType', () => {
+        const monthlyPeriodId = '201204'
+        expect(initialPeriodValue(monthlyPeriodId, initialWorkflow)).toEqual({})
+    })
+    it('returns a parsed period object if the periodId matches the workflow periodType', () => {
+        const dailyPeriodId = '20120404'
+        expect(initialPeriodValue(dailyPeriodId, initialWorkflow)).toEqual(
+            expect.objectContaining({
+                displayName: '2012-04-04',
+                endDate: '2012-04-04',
+                id: '20120404',
+                iso: '20120404',
+                startDate: '2012-04-04',
+                year: 2012,
+            })
+        )
+    })
+})
+
+describe('initialOrgUnitValue', () => {
+    it('returns an empty object by default', () => {
+        expect(initialOrgUnitValue()).toEqual({})
+    })
+    it('returns an empty object when not supplying a path', () => {
+        expect(initialOrgUnitValue(undefined, 'test')).toEqual({})
+    })
+    it('returns an empty object when not supplying a displayName', () => {
+        expect(initialOrgUnitValue('test', undefined)).toEqual({})
+    })
+    it('returns an object when supplying both params', () => {
+        expect(initialOrgUnitValue('/path', 'Display name')).toEqual({
+            path: '/path',
+            displayName: 'Display name',
+        })
+    })
+})

--- a/src/top-bar/selection/use-selection-context.test.js
+++ b/src/top-bar/selection/use-selection-context.test.js
@@ -70,7 +70,8 @@ describe('useSelectionContext', () => {
         readQueryParams.mockImplementation(() => ({
             wf: 'rIUL3hYOjJc',
             pe: '20110203',
-            ou: 'abc',
+            ou: '/abc',
+            ouDisplayName: 'test',
         }))
 
         const { result } = renderHook(() => useSelectionContext(), { wrapper })
@@ -85,10 +86,12 @@ describe('useSelectionContext', () => {
                 year: 2011,
             })
         )
-        expect(result.current.orgUnit).toEqual({ path: 'abc' })
-        // TODO: add tests for dealing with invalid query params
-        // once that has been implemented for org-units too.
+        expect(result.current.orgUnit).toEqual({
+            path: '/abc',
+            displayName: 'test',
+        })
     })
+
     describe('functions returned from the hook update the state and url', () => {
         it('setOpenedSelect', () => {
             const mock = jest.fn()


### PR DESCRIPTION
This adds a simple version of the org-unit-tree to the top-bar/context-selector. This is not according to [the design specs](https://docs.google.com/document/d/1p3tiLkXWJtCw0UYsccDXyjLbhZzrhUkeev9WMQCNUIk/edit#heading=h.ip3lyxautw8i), but it was decided this is good enough for the MVP (initial release in 2.37).

One possibly controversial part is that I decided to store both the `path` and the `displayName` of the org-unit in the URL. This has a huge practical benefit, because this means we can now display the top-bar correctly on page load, and after navigation without having to do an additional request. It does cause the URL to look pretty ugly though, mainly because a `path` includes slashes and they are all encoded in the url.

The alternative would be to simply store the org-unit's `id` in the URL, and then the component could do a request to fetch relevant the org-unit details if required....