### PR TITLE
fix: import src/locales/index.js

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -49,6 +49,9 @@ jobs:
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
+            - name: Generate translations
+              run: yarn d2-app-scripts i18n generate
+
             - name: Lint
               run: yarn lint
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,3 +1,4 @@
 import { App } from './app.js'
+import '../locales/index.js'
 
 export default App


### PR DESCRIPTION
`src/locales/index.js` needs to be imported at least once in order for the correct translations matching the user's configured language to be loaded.