### PR TITLE
fix: handle UNAPPROVED_ABOVE status

### DIFF
--- a/src/shared/status-tag/status-tag.js
+++ b/src/shared/status-tag/status-tag.js
@@ -22,6 +22,7 @@ StatusTag.propTypes = {
         'UNAPPROVED_READY',
         'UNAPPROVED_WAITING',
         'UNAPPROVED_ELSEWHERE',
+        'UNAPPROVED_ABOVE',
         'UNAPPROVABLE',
     ]),
 }

--- a/src/shared/status-tag/use-approval-state.js
+++ b/src/shared/status-tag/use-approval-state.js
@@ -37,6 +37,7 @@ const useApprovalState = approvalState => {
 
         case 'UNAPPROVED_WAITING':
         case 'UNAPPROVED_ELSEWHERE':
+        case 'UNAPPROVED_ABOVE':
             return {
                 icon: Waiting,
                 displayName: i18n.t('Waiting'),

--- a/src/shared/status-tag/use-approval-state.js
+++ b/src/shared/status-tag/use-approval-state.js
@@ -50,6 +50,9 @@ const useApprovalState = approvalState => {
                 displayName: i18n.t('Cannot approve'),
                 type: 'negative',
             }
+
+        default:
+            throw new Error(`Unknown approval state: '${approvalState}'`)
     }
 }
 


### PR DESCRIPTION
Handle the `UNAPPROVED_ABOVE` status in the same way we handle `UNAPPROVED_WAITING` and `UNAPPROVED_ELSEWHERE`.