### PR TITLE
feat: period conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "@testing-library/react-hooks": "^7.0.1",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
-        "identity-obj-proxy": "^3.0.0"
+        "identity-obj-proxy": "^3.0.0",
+        "mockdate": "^3.0.5"
     },
     "dependencies": {
         "@dhis2/app-runtime": "^2.8.0",

--- a/src/app-context/app-provider.js
+++ b/src/app-context/app-provider.js
@@ -23,7 +23,7 @@ const query = {
                 'displayName',
                 'dataApprovalLevels',
                 'periodType',
-                'dataSets[id,displayName]',
+                'dataSets[id,displayName,periodType]',
             ],
         },
     },

--- a/src/top-bar/period-select/fixed-periods.js
+++ b/src/top-bar/period-select/fixed-periods.js
@@ -756,15 +756,17 @@ export const getFixedPeriodsForTypeAndDateRange = (
         getFixedPeriodsByTypeAndYear(type, year)
             .reverse()
             .forEach(period => {
-                const isAfterPeriodStart =
-                    new Date(period.startDate) >= startDate
-                const isBeforePeriodEnd = new Date(period.endDate) <= endDate
+                const periodEnd = new Date(period.endDate)
+                // exclude periods that end before start date
+                const endsAfterPeriodStart = periodEnd >= startDate
+                // exclude periods that end after end date
+                const endsBeforePeriodEnd = periodEnd <= endDate
 
-                if (!isAfterPeriodStart) {
+                if (!endsAfterPeriodStart) {
                     startDateReached = true
                 }
 
-                if (isAfterPeriodStart && isBeforePeriodEnd) {
+                if (endsAfterPeriodStart && endsBeforePeriodEnd) {
                     convertedPeriods.push(period)
                 }
             })

--- a/src/top-bar/period-select/fixed-periods.js
+++ b/src/top-bar/period-select/fixed-periods.js
@@ -13,24 +13,24 @@ import i18n from '@dhis2/d2-i18n'
  */
 
 // Period types
-const DAILY = 'Daily'
-const WEEKLY = 'Weekly'
-const WEEKLY_WEDNESDAY = 'WeeklyWednesday'
-const WEEKLY_THURSDAY = 'WeeklyThursday'
-const WEEKLY_SATURDAY = 'WeeklySaturday'
-const WEEKLY_SUNDAY = 'WeeklySunday'
-const BI_WEEKLY = 'BiWeekly'
-const MONTHLY = 'Monthly'
-const BI_MONTHLY = 'BiMonthly'
-const QUARTERLY = 'Quarterly'
-const SIX_MONTHLY = 'SixMonthly'
-const SIX_MONTHLY_APRIL = 'SixMonthlyApril'
-// const SIX_MONTHLY_NOV = 'SixMonthlyNov'
-const YEARLY = 'Yearly'
-const FINANCIAL_APRIL = 'FinancialApril'
-const FINANCIAL_JULY = 'FinancialJuly'
-const FINANCIAL_OCT = 'FinancialOct'
-const FINANCIAL_NOV = 'FinancialNov'
+export const DAILY = 'Daily'
+export const WEEKLY = 'Weekly'
+export const WEEKLY_WEDNESDAY = 'WeeklyWednesday'
+export const WEEKLY_THURSDAY = 'WeeklyThursday'
+export const WEEKLY_SATURDAY = 'WeeklySaturday'
+export const WEEKLY_SUNDAY = 'WeeklySunday'
+export const BI_WEEKLY = 'BiWeekly'
+export const MONTHLY = 'Monthly'
+export const BI_MONTHLY = 'BiMonthly'
+export const QUARTERLY = 'Quarterly'
+export const SIX_MONTHLY = 'SixMonthly'
+export const SIX_MONTHLY_APRIL = 'SixMonthlyApril'
+// export const SIX_MONTHLY_NOV = 'SixMonthlyNov'
+export const YEARLY = 'Yearly'
+export const FINANCIAL_APRIL = 'FinancialApril'
+export const FINANCIAL_JULY = 'FinancialJuly'
+export const FINANCIAL_OCT = 'FinancialOct'
+export const FINANCIAL_NOV = 'FinancialNov'
 
 const getMonthName = key => {
     const monthNames = [
@@ -775,4 +775,69 @@ export const getFixedPeriodsForTypeAndDateRange = (
     }
 
     return convertedPeriods.reverse()
+}
+
+const FIXED_PERIODS_BY_LENGTH = [
+    [DAILY],
+    [WEEKLY, WEEKLY_WEDNESDAY, WEEKLY_THURSDAY, WEEKLY_SATURDAY, WEEKLY_SUNDAY],
+    [BI_WEEKLY],
+    [MONTHLY],
+    [BI_MONTHLY],
+    [QUARTERLY],
+    [SIX_MONTHLY, SIX_MONTHLY_APRIL],
+    [YEARLY, FINANCIAL_APRIL, FINANCIAL_JULY, FINANCIAL_OCT, FINANCIAL_NOV],
+]
+
+export const PERIOD_GREATER = 1
+export const PERIOD_EQUAL = 0
+export const PERIOD_SHORTER = -1
+
+/*
+ * IF left < right THEN return  1
+ * IF left > right THEN return -1
+ * IF left = right THEN return  0
+ *
+ * Why right > left = 1 and not the other way?
+ * When partially applying this function, it makes sense this way:
+ *
+ * const compareWithWeekly = partial(compareFixedPeriodLength, 'WEEKLY')
+ * const isGreater = compareWithWeekly('YEARLY') === PERIOD_GREATER
+ * -> isGreater is true
+ *
+ * @param {string} right
+ * @param {string} left
+ * @returns {Int}
+ */
+export const compareFixedPeriodLength = (left, right) => {
+    const leftIndex = FIXED_PERIODS_BY_LENGTH.findIndex(types => types.includes(left))
+    const rightIndex = FIXED_PERIODS_BY_LENGTH.findIndex(types => types.includes(right))
+
+    if (leftIndex === rightIndex) return PERIOD_EQUAL
+    return leftIndex > rightIndex ? PERIOD_SHORTER : PERIOD_GREATER
+}
+
+export const getLastSubPeriodForTypeAndPeriod = (type, period) => {
+    const fullPeriod = parsePeriodId(period.id)
+
+    if (!fullPeriod) {
+        throw new Error(
+            `Can't parse period with id "${period.id}"`
+        )
+    }
+
+    const { type: periodType } = parsePeriodId(period.id).periodType
+    if (compareFixedPeriodLength(type, periodType) !== PERIOD_GREATER) {
+        throw new Error(
+            `The sub-period type "${type}" is not shorter that the period's type ("${periodType}")`
+        )
+    }
+
+    // .slice(-1) returns an array with the last item
+    const [lastSubPeriod] = getFixedPeriodsForTypeAndDateRange(
+        type,
+        period.startDate,
+        period.endDate
+    ).slice(-1)
+
+    return lastSubPeriod
 }

--- a/src/top-bar/period-select/fixed-periods.js
+++ b/src/top-bar/period-select/fixed-periods.js
@@ -738,3 +738,39 @@ export const parsePeriodId = (id, allowedTypes) => {
         periodType,
     }
 }
+
+export const getFixedPeriodsForTypeAndDateRange = (
+    type,
+    startDate,
+    endDate
+) => {
+    // Allow dates and date-strings
+    startDate = startDate instanceof Date ? startDate : new Date(startDate)
+    endDate = endDate instanceof Date ? endDate : new Date(endDate)
+
+    let year = endDate.getFullYear()
+    let startDateReached = false
+    const convertedPeriods = []
+
+    while (!startDateReached) {
+        getFixedPeriodsByTypeAndYear(type, year)
+            .reverse()
+            .forEach(period => {
+                const isAfterPeriodStart =
+                    new Date(period.startDate) >= startDate
+                const isBeforePeriodEnd = new Date(period.endDate) <= endDate
+
+                if (!isAfterPeriodStart) {
+                    startDateReached = true
+                }
+
+                if (isAfterPeriodStart && isBeforePeriodEnd) {
+                    convertedPeriods.push(period)
+                }
+            })
+
+        --year
+    }
+
+    return convertedPeriods.reverse()
+}

--- a/src/top-bar/period-select/fixed-periods.test.js
+++ b/src/top-bar/period-select/fixed-periods.test.js
@@ -1,4 +1,5 @@
 import {
+    getFixedPeriodsForTypeAndDateRange,
     getFixedPeriodType,
     getFixedPeriodTypes,
     parsePeriodId,
@@ -779,6 +780,91 @@ describe('fixedPeriods utils', () => {
             const period = parsePeriodId('2014April')
             expect(period.periodType.type).toEqual('FinancialApril')
             expect(period).toMatchSnapshot()
+        })
+    })
+
+    describe('getFixedPeriodsForTypeAndDateRange', () => {
+        it('should return an empty array if the period exceeds the date range', () => {
+            expect(
+                getFixedPeriodsForTypeAndDateRange(
+                    'Yearly',
+                    '2021-04-08',
+                    '2021-06-06'
+                )
+            ).toEqual([])
+        })
+        it('should return the expected result even when the date range spans multiple years', () => {
+            expect(
+                getFixedPeriodsForTypeAndDateRange(
+                    'Monthly',
+                    '2020-08-08',
+                    '2021-06-06'
+                )
+            ).toEqual([
+                {
+                    displayName: 'September 2020',
+                    endDate: '2020-09-30',
+                    id: '202009',
+                    iso: '202009',
+                    startDate: '2020-09-01',
+                },
+                {
+                    displayName: 'October 2020',
+                    endDate: '2020-10-31',
+                    id: '202010',
+                    iso: '202010',
+                    startDate: '2020-10-01',
+                },
+                {
+                    displayName: 'November 2020',
+                    endDate: '2020-11-30',
+                    id: '202011',
+                    iso: '202011',
+                    startDate: '2020-11-01',
+                },
+                {
+                    displayName: 'December 2020',
+                    endDate: '2020-12-31',
+                    id: '202012',
+                    iso: '202012',
+                    startDate: '2020-12-01',
+                },
+                {
+                    displayName: 'January 2021',
+                    endDate: '2021-01-31',
+                    id: '202101',
+                    iso: '202101',
+                    startDate: '2021-01-01',
+                },
+                {
+                    displayName: 'February 2021',
+                    endDate: '2021-02-28',
+                    id: '202102',
+                    iso: '202102',
+                    startDate: '2021-02-01',
+                },
+                {
+                    displayName: 'March 2021',
+                    endDate: '2021-03-31',
+                    id: '202103',
+                    iso: '202103',
+                    startDate: '2021-03-01',
+                },
+                {
+                    displayName: 'April 2021',
+                    endDate: '2021-04-30',
+                    id: '202104',
+                    iso: '202104',
+                    startDate: '2021-04-01',
+                },
+                {
+                    displayName: 'May 2021',
+                    endDate: '2021-05-31',
+                    id: '202105',
+                    iso: '202105',
+                    startDate: '2021-05-01',
+                },
+            ])
         })
     })
 })

--- a/src/top-bar/period-select/fixed-periods.test.js
+++ b/src/top-bar/period-select/fixed-periods.test.js
@@ -1,7 +1,30 @@
 import {
+    PERIOD_GREATER,
+    PERIOD_EQUAL,
+    PERIOD_SHORTER,
+    DAILY,
+    WEEKLY,
+    WEEKLY_WEDNESDAY,
+    WEEKLY_THURSDAY,
+    WEEKLY_SATURDAY,
+    WEEKLY_SUNDAY,
+    BI_WEEKLY,
+    MONTHLY,
+    BI_MONTHLY,
+    QUARTERLY,
+    SIX_MONTHLY,
+    SIX_MONTHLY_APRIL,
+    YEARLY,
+    FINANCIAL_APRIL,
+    FINANCIAL_JULY,
+    FINANCIAL_OCT,
+    FINANCIAL_NOV,
+    compareFixedPeriodLength,
     getFixedPeriodsForTypeAndDateRange,
+    getFixedPeriodsByTypeAndYear,
     getFixedPeriodType,
     getFixedPeriodTypes,
+    getLastSubPeriodForTypeAndPeriod,
     parsePeriodId,
     getYearOffsetFromNow,
 } from './fixed-periods.js'
@@ -910,6 +933,214 @@ describe('fixedPeriods utils', () => {
                     startDate: '2021-05-01',
                 },
             ])
+        })
+    })
+
+    describe('compareFixedPeriodLength', () => {
+        const notEqual = [
+            [DAILY, WEEKLY],
+            [DAILY, WEEKLY_WEDNESDAY],
+            [DAILY, WEEKLY_THURSDAY],
+            [DAILY, WEEKLY_SATURDAY],
+            [DAILY, WEEKLY_SUNDAY],
+            [DAILY, BI_WEEKLY],
+            [DAILY, MONTHLY],
+            [DAILY, BI_MONTHLY],
+            [DAILY, QUARTERLY],
+            [DAILY, SIX_MONTHLY],
+            [DAILY, SIX_MONTHLY_APRIL],
+            [DAILY, YEARLY],
+            [DAILY, FINANCIAL_APRIL],
+            [DAILY, FINANCIAL_JULY],
+            [DAILY, FINANCIAL_OCT],
+            [DAILY, FINANCIAL_NOV],
+            [WEEKLY, BI_WEEKLY],
+            [WEEKLY, MONTHLY],
+            [WEEKLY, BI_MONTHLY],
+            [WEEKLY, QUARTERLY],
+            [WEEKLY, SIX_MONTHLY],
+            [WEEKLY, SIX_MONTHLY_APRIL],
+            [WEEKLY, YEARLY],
+            [WEEKLY, FINANCIAL_APRIL],
+            [WEEKLY, FINANCIAL_JULY],
+            [WEEKLY, FINANCIAL_OCT],
+            [WEEKLY, FINANCIAL_NOV],
+            [WEEKLY_WEDNESDAY, BI_WEEKLY],
+            [WEEKLY_WEDNESDAY, MONTHLY],
+            [WEEKLY_WEDNESDAY, BI_MONTHLY],
+            [WEEKLY_WEDNESDAY, QUARTERLY],
+            [WEEKLY_WEDNESDAY, SIX_MONTHLY],
+            [WEEKLY_WEDNESDAY, SIX_MONTHLY_APRIL],
+            [WEEKLY_WEDNESDAY, YEARLY],
+            [WEEKLY_WEDNESDAY, FINANCIAL_APRIL],
+            [WEEKLY_WEDNESDAY, FINANCIAL_JULY],
+            [WEEKLY_WEDNESDAY, FINANCIAL_OCT],
+            [WEEKLY_WEDNESDAY, FINANCIAL_NOV],
+            [WEEKLY_THURSDAY, BI_WEEKLY],
+            [WEEKLY_THURSDAY, MONTHLY],
+            [WEEKLY_THURSDAY, BI_MONTHLY],
+            [WEEKLY_THURSDAY, QUARTERLY],
+            [WEEKLY_THURSDAY, SIX_MONTHLY],
+            [WEEKLY_THURSDAY, SIX_MONTHLY_APRIL],
+            [WEEKLY_THURSDAY, YEARLY],
+            [WEEKLY_THURSDAY, FINANCIAL_APRIL],
+            [WEEKLY_THURSDAY, FINANCIAL_JULY],
+            [WEEKLY_THURSDAY, FINANCIAL_OCT],
+            [WEEKLY_THURSDAY, FINANCIAL_NOV],
+            [WEEKLY_SATURDAY, BI_WEEKLY],
+            [WEEKLY_SATURDAY, MONTHLY],
+            [WEEKLY_SATURDAY, BI_MONTHLY],
+            [WEEKLY_SATURDAY, QUARTERLY],
+            [WEEKLY_SATURDAY, SIX_MONTHLY],
+            [WEEKLY_SATURDAY, SIX_MONTHLY_APRIL],
+            [WEEKLY_SATURDAY, YEARLY],
+            [WEEKLY_SATURDAY, FINANCIAL_APRIL],
+            [WEEKLY_SATURDAY, FINANCIAL_JULY],
+            [WEEKLY_SATURDAY, FINANCIAL_OCT],
+            [WEEKLY_SATURDAY, FINANCIAL_NOV],
+            [WEEKLY_SUNDAY, BI_WEEKLY],
+            [WEEKLY_SUNDAY, MONTHLY],
+            [WEEKLY_SUNDAY, BI_MONTHLY],
+            [WEEKLY_SUNDAY, QUARTERLY],
+            [WEEKLY_SUNDAY, SIX_MONTHLY],
+            [WEEKLY_SUNDAY, SIX_MONTHLY_APRIL],
+            [WEEKLY_SUNDAY, YEARLY],
+            [WEEKLY_SUNDAY, FINANCIAL_APRIL],
+            [WEEKLY_SUNDAY, FINANCIAL_JULY],
+            [WEEKLY_SUNDAY, FINANCIAL_OCT],
+            [WEEKLY_SUNDAY, FINANCIAL_NOV],
+            [BI_WEEKLY, MONTHLY],
+            [BI_WEEKLY, BI_MONTHLY],
+            [BI_WEEKLY, QUARTERLY],
+            [BI_WEEKLY, SIX_MONTHLY],
+            [BI_WEEKLY, SIX_MONTHLY_APRIL],
+            [BI_WEEKLY, YEARLY],
+            [BI_WEEKLY, FINANCIAL_APRIL],
+            [BI_WEEKLY, FINANCIAL_JULY],
+            [BI_WEEKLY, FINANCIAL_OCT],
+            [BI_WEEKLY, FINANCIAL_NOV],
+            [MONTHLY, BI_MONTHLY],
+            [MONTHLY, QUARTERLY],
+            [MONTHLY, SIX_MONTHLY],
+            [MONTHLY, SIX_MONTHLY_APRIL],
+            [MONTHLY, YEARLY],
+            [MONTHLY, FINANCIAL_APRIL],
+            [MONTHLY, FINANCIAL_JULY],
+            [MONTHLY, FINANCIAL_OCT],
+            [MONTHLY, FINANCIAL_NOV],
+            [BI_MONTHLY, QUARTERLY],
+            [BI_MONTHLY, SIX_MONTHLY],
+            [BI_MONTHLY, SIX_MONTHLY_APRIL],
+            [BI_MONTHLY, YEARLY],
+            [BI_MONTHLY, FINANCIAL_APRIL],
+            [BI_MONTHLY, FINANCIAL_JULY],
+            [BI_MONTHLY, FINANCIAL_OCT],
+            [BI_MONTHLY, FINANCIAL_NOV],
+            [SIX_MONTHLY, YEARLY],
+            [SIX_MONTHLY, FINANCIAL_APRIL],
+            [SIX_MONTHLY, FINANCIAL_JULY],
+            [SIX_MONTHLY, FINANCIAL_OCT],
+            [SIX_MONTHLY, FINANCIAL_NOV],
+            [SIX_MONTHLY_APRIL, YEARLY],
+            [SIX_MONTHLY_APRIL, FINANCIAL_APRIL],
+            [SIX_MONTHLY_APRIL, FINANCIAL_JULY],
+            [SIX_MONTHLY_APRIL, FINANCIAL_OCT],
+            [SIX_MONTHLY_APRIL, FINANCIAL_NOV],
+        ]
+
+        it('should be shorter', () => {
+            notEqual.forEach(([shorter, greater]) => {
+                const result = compareFixedPeriodLength(greater, shorter)
+                expect(result).toBe(PERIOD_SHORTER)
+            })
+        })
+
+        it('should be greater', () => {
+            notEqual.forEach(([shorter, greater]) => {
+                const result = compareFixedPeriodLength(shorter, greater)
+                expect(result).toBe(PERIOD_GREATER)
+            })
+        })
+
+        const equal = [
+            [DAILY, DAILY],
+            [WEEKLY, WEEKLY],
+            [WEEKLY, WEEKLY_WEDNESDAY],
+            [WEEKLY, WEEKLY_THURSDAY],
+            [WEEKLY, WEEKLY_SATURDAY],
+            [WEEKLY, WEEKLY_SUNDAY],
+            [WEEKLY_WEDNESDAY, WEEKLY_WEDNESDAY],
+            [WEEKLY_WEDNESDAY, WEEKLY_THURSDAY],
+            [WEEKLY_WEDNESDAY, WEEKLY_SATURDAY],
+            [WEEKLY_WEDNESDAY, WEEKLY_SUNDAY],
+            [WEEKLY_THURSDAY, WEEKLY_THURSDAY],
+            [WEEKLY_THURSDAY, WEEKLY_SATURDAY],
+            [WEEKLY_THURSDAY, WEEKLY_SUNDAY],
+            [WEEKLY_SATURDAY, WEEKLY_SATURDAY],
+            [WEEKLY_SATURDAY, WEEKLY_SUNDAY],
+            [WEEKLY_SUNDAY, WEEKLY_SUNDAY],
+            [BI_WEEKLY, BI_WEEKLY],
+            [MONTHLY, MONTHLY],
+            [BI_MONTHLY, BI_MONTHLY],
+            [QUARTERLY, QUARTERLY],
+            [SIX_MONTHLY, SIX_MONTHLY],
+            [SIX_MONTHLY, SIX_MONTHLY_APRIL],
+            [SIX_MONTHLY_APRIL, SIX_MONTHLY_APRIL],
+            [YEARLY, YEARLY],
+            [YEARLY, FINANCIAL_APRIL],
+            [YEARLY, FINANCIAL_JULY],
+            [YEARLY, FINANCIAL_OCT],
+            [YEARLY, FINANCIAL_NOV],
+            [FINANCIAL_APRIL, FINANCIAL_APRIL],
+            [FINANCIAL_APRIL, FINANCIAL_JULY],
+            [FINANCIAL_APRIL, FINANCIAL_OCT],
+            [FINANCIAL_APRIL, FINANCIAL_NOV],
+            [FINANCIAL_JULY, FINANCIAL_JULY],
+            [FINANCIAL_JULY, FINANCIAL_OCT],
+            [FINANCIAL_JULY, FINANCIAL_NOV],
+            [FINANCIAL_OCT, FINANCIAL_OCT],
+            [FINANCIAL_OCT, FINANCIAL_NOV],
+            [FINANCIAL_NOV, FINANCIAL_NOV],
+        ]
+
+        it('should equal', () => {
+            equal.forEach(([left, right]) => {
+                const result = compareFixedPeriodLength(left, right)
+                expect(result).toBe(PERIOD_EQUAL)
+            })
+        })
+    })
+
+    describe('getLastSubPeriodForTypeAndPeriod', () => {
+        it("should throw an error if the period's type is equal to the type", () => {
+            expect(() => getLastSubPeriodForTypeAndPeriod(DAILY, DAILY)).toThrow()
+        })
+
+        it("should throw an error if the period's type is shorter than the type", () => {
+            expect(() => getLastSubPeriodForTypeAndPeriod(WEEKLY, DAILY)).toThrow()
+        })
+
+        it('should return the last weekly period of the year 2021', () => {
+            const yearPeriod = {
+                endDate: '2021-12-31',
+                startDate: '2021-01-01',
+                displayName: '2021',
+                iso: '2021',
+                id: '2021'
+            }
+
+            const lastWeeklyPeriod = getLastSubPeriodForTypeAndPeriod(
+                WEEKLY,
+                yearPeriod
+            )
+
+            expect(lastWeeklyPeriod).toEqual({
+              startDate: '2021-12-20',
+              iso: '2021W51',
+              id: '2021W51',
+              endDate: '2021-12-26',
+              displayName: 'Week 51 - 2021-12-20 - 2021-12-26'
+            })
         })
     })
 })

--- a/src/top-bar/period-select/fixed-periods.test.js
+++ b/src/top-bar/period-select/fixed-periods.test.js
@@ -796,11 +796,56 @@ describe('fixedPeriods utils', () => {
         it('should return the expected result even when the date range spans multiple years', () => {
             expect(
                 getFixedPeriodsForTypeAndDateRange(
+                    'Weekly',
+                    '2021-04-01',
+                    '2021-04-30'
+                )
+            ).toEqual([
+                {
+                    displayName: 'Week 13 - 2021-03-29 - 2021-04-04',
+                    endDate: '2021-04-04',
+                    id: '2021W13',
+                    iso: '2021W13',
+                    startDate: '2021-03-29',
+                },
+                {
+                    displayName: 'Week 14 - 2021-04-05 - 2021-04-11',
+                    endDate: '2021-04-11',
+                    id: '2021W14',
+                    iso: '2021W14',
+                    startDate: '2021-04-05',
+                },
+                {
+                    displayName: 'Week 15 - 2021-04-12 - 2021-04-18',
+                    endDate: '2021-04-18',
+                    id: '2021W15',
+                    iso: '2021W15',
+                    startDate: '2021-04-12',
+                },
+                {
+                    displayName: 'Week 16 - 2021-04-19 - 2021-04-25',
+                    endDate: '2021-04-25',
+                    id: '2021W16',
+                    iso: '2021W16',
+                    startDate: '2021-04-19',
+                },
+            ])
+        })
+        it('should return the expected result even when the date range spans multiple years', () => {
+            expect(
+                getFixedPeriodsForTypeAndDateRange(
                     'Monthly',
                     '2020-08-08',
                     '2021-06-06'
                 )
             ).toEqual([
+                {
+                    displayName: 'August 2020',
+                    endDate: '2020-08-31',
+                    id: '202008',
+                    iso: '202008',
+                    startDate: '2020-08-01',
+                },
                 {
                     displayName: 'September 2020',
                     endDate: '2020-09-30',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10859,6 +10859,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 moment@^2.24.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
This new period helper can help when converting one period to another. It supports date ranges that span multiple years. The way I see this being used is like this:
```js
const workflowPeriodId = '202104' // This is a Monthly periodID
const { startDate, endDate } = parsePeriodId(workflowPeriodId) // '2021-04-01' , '2021-04-30'
const dailyPeriodsInWorkflowPeriod = getFixedPeriodsForTypeAndDateRange(
    'Weekly'
    startDate,
    endDate
)
/*
[
    {
        displayName: 'Week 14 - 2021-04-05 - 2021-04-11',
        endDate: '2021-04-11',
        id: '2021W14',
        iso: '2021W14',
        startDate: '2021-04-05',
    },
    {
        displayName: 'Week 15 - 2021-04-12 - 2021-04-18',
        endDate: '2021-04-18',
        id: '2021W15',
        iso: '2021W15',
        startDate: '2021-04-12',
    },
    {
        displayName: 'Week 16 - 2021-04-19 - 2021-04-25',
        endDate: '2021-04-25',
        id: '2021W16',
        iso: '2021W16',
        startDate: '2021-04-19',
    },
]
*/
const lastDailyPeriodId = dailyPeriodsInWorkflowPeriod[dailyPeriodsInWorkflowPeriod -1].id // 2021W16
const allDailyPeriodIds = dailyPeriodsInWorkflowPeriod.map(({ id }) => id) // [ '2021W14', '2021W15', '2021W16' ]
```

I think this should be enough to enable the behaviour discussed in [this Slack thread](https://dhis2.slack.com/archives/C025FSBEKED/p1625143925081400).