### PR TITLE
fix: use '-:-' instead of null as i18n namespace separator

### DIFF
--- a/src/bottom-bar/accept-button/accept-button.js
+++ b/src/bottom-bar/accept-button/accept-button.js
@@ -11,7 +11,7 @@ const AcceptButton = () => {
     const { show } = useAlert(
         i18n.t('Acceptance failed: {{error}}', {
             error: error ? error.toString() : '',
-            nsSeparator: null,
+            nsSeparator: '-:-',
         })
     )
 

--- a/src/bottom-bar/unaccept-button/unaccept-button.js
+++ b/src/bottom-bar/unaccept-button/unaccept-button.js
@@ -11,7 +11,7 @@ const UnacceptButton = () => {
     const { show } = useAlert(
         i18n.t('Unacceptance failed: {{error}}', {
             error: error ? error.toString() : '',
-            nsSeparator: null,
+            nsSeparator: '-:-',
         })
     )
 

--- a/src/bottom-bar/unapprove-button/unapprove-button.js
+++ b/src/bottom-bar/unapprove-button/unapprove-button.js
@@ -11,7 +11,7 @@ const UnapproveButton = () => {
     const { show } = useAlert(
         i18n.t('Unapproval failed: {{error}}', {
             error: error ? error.toString() : '',
-            nsSeparator: null,
+            nsSeparator: '-:-',
         })
     )
 


### PR DESCRIPTION
Using `null` as a namespace separator may cause issues if we wish to use namespaces in the future, so this PR replaces it with `'-:-'`.