### PR TITLE
chore(deps): update app-runtime to latest

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -7,6 +7,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "POT-Creation-Date: 2021-08-12T11:12:06.430Z\n"
 "PO-Revision-Date: 2021-08-12T11:12:06.430Z\n"
+"POT-Creation-Date: 2021-08-12T12:36:19.640Z\n"
+"PO-Revision-Date: 2021-08-12T12:36:19.640Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -78,6 +78,9 @@ msgstr ""
 "{{- workflowName}} has multiple data sets. Choose a data set from the tabs "
 "above."
 
+msgid "Loading data set"
+msgstr "Loading data set"
+
 msgid "There was a problem displaying this data set"
 msgstr "There was a problem displaying this data set"
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,11 @@
         "start": "d2-app-scripts start",
         "test": "d2-app-scripts test"
     },
+    "resolutions": {
+        "@dhis2/app-runtime": "2.9.0-beta.6"
+    },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^7.1.0",
+        "@dhis2/cli-app-scripts": "^7.1.1",
         "@dhis2/cli-style": "^9.0.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
@@ -26,7 +29,7 @@
         "mockdate": "^3.0.5"
     },
     "dependencies": {
-        "@dhis2/app-runtime": "^2.8.0",
+        "@dhis2/app-runtime": "^2.9.0-beta.6",
         "@dhis2/ui": "^6.10.5",
         "history": "^5.0.0",
         "prop-types": "^15.7.2",

--- a/src/data-workspace/display/display.js
+++ b/src/data-workspace/display/display.js
@@ -63,6 +63,17 @@ const Display = ({ dataSetId }) => {
         )
     }
 
+    if ((!called && periodIds.length) || loading) {
+        return (
+            <div className={styles.display}>
+                <div className={styles.loadingWrapper}>
+                    <CircularLoader small />
+                    {i18n.t('Loading data set')}
+                </div>
+            </div>
+        )
+    }
+
     if (error) {
         return (
             <div className={styles.display}>
@@ -84,17 +95,6 @@ const Display = ({ dataSetId }) => {
                         {i18n.t('Retry loading data set')}
                     </button>
                 </NoticeBox>
-            </div>
-        )
-    }
-
-    if ((!called && periodIds.length) || loading) {
-        return (
-            <div className={styles.display}>
-                <div className={styles.loadingWrapper}>
-                    <CircularLoader small />
-                    {i18n.t('Loading data set')}
-                </div>
             </div>
         )
     }

--- a/src/data-workspace/display/display.test.js
+++ b/src/data-workspace/display/display.test.js
@@ -137,14 +137,17 @@ describe('<Display>', () => {
 
         data.dataSetReport = []
         userEvent.click(screen.getByRole('button', 'Retry loading data set'))
-        await waitForElementToBeRemoved(() => screen.getByRole('progressbar'))
+        await waitFor(() => screen.getByRole('progressbar'))
 
-        expect(
-            screen.queryByRole(
-                'heading',
-                'There was a problem displaying this data set'
-            )
-        ).not.toBeInTheDocument()
+        await waitFor(() => {
+            expect(
+                screen.queryByRole(
+                    'heading',
+                    'There was a problem displaying this data set'
+                )
+            ).not.toBeInTheDocument()
+            expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+        })
     })
 
     it('shows a message if the data set report has no data for the seleted period and organisation unit', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.14.5", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
@@ -1842,46 +1849,48 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/app-adapter@7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-7.1.0.tgz#75bf2f379ca490fb6ff0e36765d9f4cde533ffcf"
-  integrity sha512-xi/dDXY/s/KqAFhvkJcwXh/tPcH4qZlKizDtJyHrwFGGP71pdMrEg4WBc/5gAQg1m6yziS+VoCyL43KOzVJ8WA==
+"@dhis2/app-adapter@7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-7.2.1.tgz#0b1cba3e28482e3a9cecc0b02a39e8e03eb5eb0a"
+  integrity sha512-KrPz2ilrIFGPw+gs3LtCvq3jUL7mJDw4K9X+Canhn0ZYqn5PWsTfLtcdx+ObaoQtwlMY/W/4RnMfsImEfxUb6A==
   dependencies:
     moment "^2.24.0"
 
-"@dhis2/app-runtime@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.8.0.tgz#83ca6e96c299686ee72eea3e1825e04aa53cd5d2"
-  integrity sha512-Ru6x9L61fD7ITzVaxFqx88kV5/ypB9xSr8nHgRj4EE/kHl/aVejXuwnSS2OIWh80J3mtD1dpNRN/GJ8o0x0HYg==
+"@dhis2/app-runtime@2.9.0-beta.6", "@dhis2/app-runtime@^2.8.0", "@dhis2/app-runtime@^2.9.0-beta.6":
+  version "2.9.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.9.0-beta.6.tgz#a178a23085be6c8996b9851179bf5339a158db70"
+  integrity sha512-CWW88AmmkrEzb/oSTR5XpCdUoYyViOKLEVkGeP3x1yulZ2JrsjQerd8cYcEaI0ONeHKY93XVvNyTfjAKmOU9Ow==
   dependencies:
-    "@dhis2/app-service-alerts" "2.8.0"
-    "@dhis2/app-service-config" "2.8.0"
-    "@dhis2/app-service-data" "2.8.0"
+    "@dhis2/app-service-alerts" "2.9.0-beta.6"
+    "@dhis2/app-service-config" "2.9.0-beta.6"
+    "@dhis2/app-service-data" "2.9.0-beta.6"
 
-"@dhis2/app-service-alerts@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.8.0.tgz#f480043a15b5a2b7d90a6e74931ddd3ebb65aa1c"
-  integrity sha512-hpMqdxCG9w5H2EZyLPQKcKzCdp/Sof68ZGd85lNHo+1c10+1pWhKAjt/p3zoRllHppp17TbEgKoXa1oRx2NeHg==
+"@dhis2/app-service-alerts@2.9.0-beta.6":
+  version "2.9.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.9.0-beta.6.tgz#3af01c138d4082f8c63632e56222f7648adb35db"
+  integrity sha512-lwbcm4os7+tYsmoSzH61Z6p/nLJgzKMlRXyp2C3+onmo3qiO/rHL7C/a5SkQ1YaPK5fMY6RyQzLj4J1ZWeqBIw==
 
-"@dhis2/app-service-config@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.8.0.tgz#4ce7520e28a7700fa11ad7bcba6468a0a58751a4"
-  integrity sha512-SZnoa2EjsgV8a1QfnSk6fqxORV3pRcA+SYyz/H/nkr/VodkdgmO5CiwlZxXW8pG+4i6sbMGjGualam2jHF34wg==
+"@dhis2/app-service-config@2.9.0-beta.6":
+  version "2.9.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.9.0-beta.6.tgz#ef14547b5178f6afdbf9232b9fdf316acc8825b3"
+  integrity sha512-ik9NE48wZP1s7RliDufeqJgrCOmggG1s37+iRdwjMia0lzqhIV3ATqkgOqSmRAF8YNgpDjRDcU8hJXCVDGx7EQ==
 
-"@dhis2/app-service-data@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.8.0.tgz#9cd347127968cb6f3c8a4ab0fc6699ea7058f835"
-  integrity sha512-5doyL4bxRMdMXY4RtWo2O3NVGwSDOSUY3hGPXaF1TeFWAqujlPTx17uDw6wEelN6LaryAnVwId2Ep3FOV8v5MA==
-
-"@dhis2/app-shell@7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-7.1.0.tgz#676c56f13de050be0236e1a52035ba0d731febd9"
-  integrity sha512-4USqo/9pQ0YtQLnKa+pFA5tFK+QBYaHHfp+EVx8cYQ2sO0bo0mg2mrPZNPibJ5IT3COylwOBm73ZKkXU1Jwsyw==
+"@dhis2/app-service-data@2.9.0-beta.6":
+  version "2.9.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.9.0-beta.6.tgz#bb6fcac3b6e072258ece771cb76820f5754879f7"
+  integrity sha512-LX1gkhvGbJ0CDpH8QLbeOMdTjCguJgg+MYXl3/DgEMLYN+Em0Q4pyA7Xn5rh7oMR7/SwRnxHQKKTWTgXaB87+w==
   dependencies:
-    "@dhis2/app-adapter" "7.1.0"
+    react-query "^3.13.11"
+
+"@dhis2/app-shell@7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-7.2.1.tgz#a65180d95bddbda8ed39bbd1e95c4a535d1f2a19"
+  integrity sha512-FhHHJ95qnLRSJApdXmPQzeEkiRqPygsZiNIB1GH0x4V+aQdYXYGziGp6vrkxOwOYT0Mf0zuWNjpJQwir4RqPLQ==
+  dependencies:
+    "@dhis2/app-adapter" "7.2.1"
     "@dhis2/app-runtime" "^2.8.0"
     "@dhis2/d2-i18n" "^1.1.0"
-    "@dhis2/ui" "^6.5.3"
+    "@dhis2/ui" "^6.10.5"
     classnames "^2.2.6"
     moment "^2.29.1"
     prop-types "^15.7.2"
@@ -1893,10 +1902,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-7.1.0.tgz#0a526cb260ecdae76c2d8c4f6d49599dca6c9114"
-  integrity sha512-yhVAgNiSsCFz51hRiA8k7CCGuvXmXiTqBqhv+axgcoxTQRIsJm1rteiTHVuig97GxAjolhxUct3Y16GL4Vd70A==
+"@dhis2/cli-app-scripts@^7.1.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-7.2.1.tgz#703fda7fc0e72beed6e9e2a78ac0ba44dd17bfb6"
+  integrity sha512-r/rtp+0d+/XeeJ5HMTL1QCv7fLWjOqlhGprPUem8+BIQwkCUfbMRtb6OdJlxbaYJ5qpDUp0K+2ujSg9a0HtHaQ==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -1905,7 +1914,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "7.1.0"
+    "@dhis2/app-shell" "7.2.1"
     "@dhis2/cli-helpers-engine" "^3.0.0"
     archiver "^3.1.1"
     axios "^0.20.0"
@@ -2075,7 +2084,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.3.1"
 
-"@dhis2/ui@^6.10.5", "@dhis2/ui@^6.5.3":
+"@dhis2/ui@^6.10.5":
   version "6.10.5"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.10.5.tgz#de9e6fb53d75a47eb23a63e20bc4a60908c5d9cd"
   integrity sha512-YM9YRVo5UXFXqHr7dJSoH8x6z3eFkaEmoHlmPht4hmCiNUK7MJK+CoBGwAXB8+UD/t7kIZhJpMJiF6mN5vCxwQ==
@@ -4237,6 +4246,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -4360,6 +4374,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -5853,7 +5881,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -9494,6 +9522,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -10094,6 +10127,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -10202,6 +10243,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -10450,6 +10496,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23:
   version "3.1.23"
@@ -10801,6 +10854,11 @@ object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.2, object.values@
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -12400,6 +12458,15 @@ react-popper@^2.2.5:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-query@^3.13.11:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.19.1.tgz#f3fbd5af48b6c47901ab230f7c028c6f845254ac"
+  integrity sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -12697,6 +12764,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
@@ -12958,17 +13030,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -14614,6 +14686,14 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -14911,10 +14991,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
https://jira.dhis2.org/browse/LIBS-200. Updating to the new app-runtime release (currently in pre-release, don't merge until this is using a stable version).

- [ ] Remove resolutions field once upgraded to stable

## Note

Two subtle things changed after the update, both in a single test. This is the line that failed initially: https://github.com/dhis2/approval-app/blob/0fee4993e3e93d35dcd7342caa49ee19e148c793/src/data-workspace/display/display.test.js#L140

1. Originally this line passed because the progressbar was in the DOM at this stage and it would later disappear (which is what waitForElementToBeRemoved requires, the element has to be present before removal). After the update the progressbar is no longer immediately in the DOM at this stage. I suspect this is related to https://github.com/tannerlinsley/react-query/issues/2481. By waiting for the progressbar instead of immediately asserting that it's there this part of the test passes again.

2. The display component has the loading conditional beneath the error display. This requires the error to be falsy (i.e. removed) during loading for the loading spinner to show up. Apparently this has changed in our beta, my assumption is that we initially would clear the error when reloading, whereas now we keep it until success. Which affects the assumptions the display component was built on.