### PR TITLE
fix: bottom bar actions

### DIFF
--- a/src/bottom-bar/approve-button/approve-modal/approve-modal.js
+++ b/src/bottom-bar/approve-button/approve-modal/approve-modal.js
@@ -10,7 +10,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useWorkflowContext } from '../../../workflow-context/index.js'
+import { useSelectionContext } from '../../../selection-context/index.js'
 import styles from './approve-modal.module.css'
 
 // Hendrik is working on some changes that will allow to get the current
@@ -20,7 +20,8 @@ import styles from './approve-modal.module.css'
 const TODO_GET_PERIOD = false
 
 const ApproveModal = ({ onApprove, onCancel, error }) => {
-    const { dataSets } = useWorkflowContext()
+    const { workflow } = useSelectionContext()
+    const { dataSets } = workflow
     const count = dataSets.length
 
     return (

--- a/src/workflow-context/workflow-provider.js
+++ b/src/workflow-context/workflow-provider.js
@@ -57,7 +57,7 @@ const WorkflowProvider = ({ children }) => {
                     wf: workflow.id,
                     pe: period.id,
                     ou: orgUnit.id,
-                }
+                },
             }}
         >
             {children}

--- a/src/workflow-context/workflow-provider.js
+++ b/src/workflow-context/workflow-provider.js
@@ -53,6 +53,11 @@ const WorkflowProvider = ({ children }) => {
                 approvalState,
                 allowedActions,
                 refresh: refetch,
+                params: {
+                    wf: workflow.id,
+                    pe: period.id,
+                    ou: orgUnit.id,
+                }
             }}
         >
             {children}


### PR DESCRIPTION
Bottom bar actions (e.g. approve and accept) were not functional due to the wrong context provider being used as well as missing data.

Although the addition of `params` to `src/workflow-context/workflow-provider.js` is not an ideal solution, it does provide an effective temporary fix until the migration of state management to redux.