### PR TITLE
fix(status-tag): remove unused status tag states and add APPROVED_ABOVE

### DIFF
--- a/src/shared/status-tag/get-tag-display-data.js
+++ b/src/shared/status-tag/get-tag-display-data.js
@@ -13,7 +13,7 @@ import { Approved, Ready, Waiting } from './icons.js'
 const getTagDisplayData = approvalState => {
     switch (approvalState) {
         case 'APPROVED_HERE':
-        case 'APPROVED_ELSEWHERE':
+        case 'APPROVED_ABOVE':
             return {
                 icon: Approved,
                 displayName: i18n.t('Approved'),
@@ -21,7 +21,6 @@ const getTagDisplayData = approvalState => {
             }
 
         case 'ACCEPTED_HERE':
-        case 'ACCEPTED_ELSEWHERE':
             return {
                 icon: Ready,
                 displayName: i18n.t('Ready for approval and accepted'),
@@ -36,7 +35,6 @@ const getTagDisplayData = approvalState => {
             }
 
         case 'UNAPPROVED_WAITING':
-        case 'UNAPPROVED_ELSEWHERE':
         case 'UNAPPROVED_ABOVE':
             return {
                 icon: Waiting,

--- a/src/shared/status-tag/get-tag-display-data.test.js
+++ b/src/shared/status-tag/get-tag-display-data.test.js
@@ -9,9 +9,7 @@ describe('getTagDisplayData', () => {
             type: 'positive',
         }
         expect(getTagDisplayData('APPROVED_HERE')).toEqual(expectedDisplayData)
-        expect(getTagDisplayData('APPROVED_ELSEWHERE')).toEqual(
-            expectedDisplayData
-        )
+        expect(getTagDisplayData('APPROVED_ABOVE')).toEqual(expectedDisplayData)
     })
     it('returns "ready for approval and accepted" display data for the correct approval states', () => {
         const expectedDisplayData = {
@@ -20,9 +18,6 @@ describe('getTagDisplayData', () => {
             type: 'neutral',
         }
         expect(getTagDisplayData('ACCEPTED_HERE')).toEqual(expectedDisplayData)
-        expect(getTagDisplayData('ACCEPTED_ELSEWHERE')).toEqual(
-            expectedDisplayData
-        )
     })
     it('returns "ready for approval" display data for the correct approval states', () => {
         const expectedDisplayData = {
@@ -41,9 +36,6 @@ describe('getTagDisplayData', () => {
             type: 'default',
         }
         expect(getTagDisplayData('UNAPPROVED_WAITING')).toEqual(
-            expectedDisplayData
-        )
-        expect(getTagDisplayData('UNAPPROVED_ELSEWHERE')).toEqual(
             expectedDisplayData
         )
         expect(getTagDisplayData('UNAPPROVED_ABOVE')).toEqual(

--- a/src/shared/status-tag/status-tag.js
+++ b/src/shared/status-tag/status-tag.js
@@ -16,12 +16,10 @@ const StatusTag = ({ approvalState }) => {
 StatusTag.propTypes = {
     approvalState: PropTypes.oneOf([
         'APPROVED_HERE',
-        'APPROVED_ELSEWHERE',
+        'APPROVED_ABOVE',
         'ACCEPTED_HERE',
-        'ACCEPTED_ELSEWHERE',
         'UNAPPROVED_READY',
         'UNAPPROVED_WAITING',
-        'UNAPPROVED_ELSEWHERE',
         'UNAPPROVED_ABOVE',
         'UNAPPROVABLE',
     ]),


### PR DESCRIPTION
The correct list of approval states is:

```
UNAPPROVABLE
UNAPPROVED_ABOVE
UNAPPROVED_WAITING
UNAPPROVED_READY
APPROVED_ABOVE
APPROVED_HERE
ACCEPTED_HERE
```

This PR adds support for `APPROVED_ABOVE` and removes the `*_ELSEWHERE` states, which have been removed from the backend.