### PR TITLE
fix(bottom-bar): update button state before unmounting via refresh

### DIFF
--- a/src/bottom-bar/approve-button/approve-button.js
+++ b/src/bottom-bar/approve-button/approve-button.js
@@ -26,8 +26,8 @@ const ApproveButton = ({ disabled }) => {
     const [approveData, { loading, error: approveError }] = useApproveData({
         onComplete: () => {
             showApprovalSuccess()
-            refresh()
             hideApprovalDialog()
+            refresh()
         },
         onError: e => setUnexpectedError(e),
     })


### PR DESCRIPTION
When calling `refresh` the workflow context reloads. This causes all child components to unmount, including the `ApproveButton`. Since `hideApprovalDialog` was being called after `refresh` this was triggering a state update on an unmounted component.

I've opted for simply changing the order of function calls, but removing the the call to `hideApprovalDialog()` would have been functionally equivalent, since unmounting the button would also hide the modal.