### PR TITLE
fix(approval-status-tag): unset max width of Tag component

### DIFF
--- a/src/shared/approval-status/approval-status-tag.js
+++ b/src/shared/approval-status/approval-status-tag.js
@@ -19,7 +19,11 @@ const ApprovalStatusTag = ({ approvalStatus, approvedAt, approvedBy }) => {
         icon: <Icon />,
     }
     const shouldRenderTooltip = isApproved(approvalStatus) && approvedAt
-    const tag = <Tag {...props}>{displayName}</Tag>
+    const tag = (
+        <Tag {...props} maxWidth="auto">
+            {displayName}
+        </Tag>
+    )
 
     if (!shouldRenderTooltip) {
         return tag


### PR DESCRIPTION
The [Tag](https://ui.dhis2.nu/#/api?id=tag) component has a max width of 240px, which is problematic for us for two reasons:

- Some of our approval status display names are long (e.g. `Waiting for lower level approval`), and will be even longer in some  languages other than English
- We render `approvedBy` and `approvedAt` with the approved status, which can result in very long strings

![image](https://user-images.githubusercontent.com/4295266/130958513-e2e8c008-2b62-4232-aa45-6a2306dc9232.png)
