### PR TITLE
fix(approval-status-tag): fix time-ago messages

### DIFF
--- a/src/shared/approval-status/approval-status-tag.js
+++ b/src/shared/approval-status/approval-status-tag.js
@@ -10,7 +10,7 @@ import {
 import { useServerDateTimeAsLocal } from './use-server-date-time-as-local.js'
 
 const ApprovalStatusTag = ({ approvalStatus, approvedAt, approvedBy }) => {
-    const approvalDateTime = useServerDateTimeAsLocal(approvedAt)
+    const approvalDateTime = approvedAt && useServerDateTimeAsLocal(approvedAt)
     const {
         icon: Icon,
         displayName,

--- a/src/shared/approval-status/use-server-date-time-as-local.js
+++ b/src/shared/approval-status/use-server-date-time-as-local.js
@@ -1,15 +1,18 @@
 import { useConfig } from '@dhis2/app-runtime'
 
+const msPerHr = 1000 * 60 * 60
+
 export const useServerDateTimeAsLocal = dateTime => {
     const { systemInfo } = useConfig()
-    const timestamp = new Date(dateTime).getTime()
     const localNow = new Date()
     const nowAtServerTimeZone = new Date(
         localNow.toLocaleString('en-US', {
             timeZone: systemInfo.serverTimeZoneId,
         })
     )
+    const timestamp = new Date(dateTime).getTime()
     const timeOffset = localNow.getTime() - nowAtServerTimeZone.getTime()
+    const timeOffsetRoundedToHours = Math.round(timeOffset / msPerHr) * msPerHr
 
-    return new Date(timestamp + timeOffset)
+    return new Date(timestamp + timeOffsetRoundedToHours)
 }


### PR DESCRIPTION
This fixes two issues:
- Sometimes `approvedAt` would be empty and the tag would show "Approved at Invalid Date" [*].
- Due to a rounding issue you'd see weird messages like "Approved in a few seconds". To address this I am rounding the timeset offset to a value in hours (I am assuming timezone differences are always measured in full hours).

[*] I believe this server behaviour is actually incorrect and have created [an issue](https://jira.dhis2.org/browse/DHIS2-11870) for it. But even after that gets fixed, it doesn't hurt to make the app slightly more robust and handle empty values a bit better.