### PR TITLE
fix: loading spinner label spacing

### DIFF
--- a/src/data-workspace/display/display.module.css
+++ b/src/data-workspace/display/display.module.css
@@ -29,6 +29,7 @@
     align-items: center;
     justify-content: center;
     color: var(--colors-grey700);
+    gap: var(--spacers-dp12);
 }
 
 .noData {


### PR DESCRIPTION
This PR fixes a lack of spacing between a loading spinner and text label that displays when loading a data-workspace.