### PR TITLE
fix: update jest mock [DHIS2-15415]

### DIFF
--- a/src/shared/approval-status/get-approval-status.test.js
+++ b/src/shared/approval-status/get-approval-status.test.js
@@ -8,9 +8,8 @@ import { Approved, Ready, Waiting } from './icons.js'
 
 jest.mock('moment', () => {
     const now = new Date()
-    const yearTwoYearsAgo = now.getFullYear() - 2
-    return () =>
-        jest.requireActual('moment')(`${yearTwoYearsAgo}-01-01T00:00:00.000Z`)
+    now.setFullYear(now.getFullYear() - 2)
+    return () => jest.requireActual('moment')(now)
 })
 
 describe('getApprovalStatusDisplayData', () => {


### PR DESCRIPTION
I thought (🤦‍♂️) I had fixed this issue with https://github.com/dhis2/approval-app/pull/276...

but unfortunately, I guessed incorrectly about how `moment.fromNow()` works. 

I thought that if today were 8 August 2023 and the comparison date was 1 January 2021, that the relative date would be "two years ago", but it turns out moment.fromNow()` rounds up and returns "three years ago" in this case.

Which causes these tests to fail again, so, in order to work with what our test expects ("two years ago"), I've updated the moment mocking to return a date exactly two years previous to the current date, so that `moment(someDate).fromNow()` should now return "two years ago".

(sorry 😔)